### PR TITLE
(WIP) Build nightly and staging keyrings in GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,58 +4,7 @@ name: ci
 on: [push, pull_request, merge_group]
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    container:
-      image: registry.fedoraproject.org/fedora:37
-    steps:
-      - run: dnf install -y git make rpmlint
-      - name: Lint specfiles
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-      - run: |
-          git config --global --add safe.directory '*'
-          rpmlint rpm_spec/*.spec
-  build-rpm:
-    runs-on: ubuntu-latest
-    env:
-      CI_SKIP_PREREQS: 1
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          repository: QubesOS/qubes-builderv2
-          path: qubes-builderv2
-      - name: Fetch latest qubes-builder tag
-        run: |
-          cd ${{ github.workspace }}/qubes-builderv2/
-          git fetch --depth=1 origin "refs/tags/*:refs/tags/*"
-      - uses: actions/checkout@v4
-        with:
-          path: securedrop-workstation-keyring
-      # See Makefile and CI_SKIP_PREREQS flag.
-      # GHA image has docker preinstalled
-      - name: Install Qubes-builderv2 dependencies
-        run: |
-          grep -v "^docker\.io$" ${{ github.workspace }}/qubes-builderv2/dependencies-debian.txt | xargs sudo apt install -y -
-      - name: Build container image
-        run: |
-          cd ${{ github.workspace }}/qubes-builderv2
-          ./tools/generate-container-image.sh docker
-      - name: Edit apparmor profile for unix-chkpwd
-        run: |
-          sudo sed -i 's/capability audit_write,$/&\n  # fix: read shadow permissions (linux-pam#686)\n  capability dac_read_search,/' /etc/apparmor.d/unix-chkpwd
-          sudo apparmor_parser -r /etc/apparmor.d/unix-chkpwd
-      - name: Build rpm
-        run: |
-          sudo apt install -y python3-pathspec
-          cd ${{ github.workspace }}/securedrop-workstation-keyring
-          make build-rpm BUILD_CONTAINER=docker BRANCH=${{ github.head_ref || github.ref_name }}
-      - name: Upload RPM
-        uses: actions/upload-artifact@v4
-        id: rpm-upload-step
-        with:
-          name: rpm
-          path: ${{ github.workspace }}/securedrop-workstation-keyring/build/*.rpm
-          retention-days: 5
-          if-no-files-found: error
+  lint-and-build:
+    uses: freedomofpress/securedrop-workstation-keyring/.github/workflows/lint-and-build.yml@main
+    with:
+      target-branch: ${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/lint-and-build.yml
+++ b/.github/workflows/lint-and-build.yml
@@ -8,6 +8,8 @@ on:
         required: true
         type: string
         description: 'Target branch for build'
+    outputs:
+      artifact-id: ${{ jobs.build-rpm.outputs.artifact-id }}
 
 jobs:
   lint:
@@ -28,6 +30,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CI_SKIP_PREREQS: 1
+    outputs:
+      artifact-id: ${{ steps.artifact-upload-step.outputs.artifact-id }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -59,9 +63,10 @@ jobs:
           cd ${{ github.workspace }}/securedrop-workstation-keyring
           make build-rpm BUILD_CONTAINER=docker BRANCH=${{ inputs.target-branch }}
       - name: Upload RPM
+        id: artifact-upload-step
         uses: actions/upload-artifact@v4
-        id: rpm-upload-step
         with:
+          name: keyring-${{ inputs.target-branch }}
           path: ${{ github.workspace }}/securedrop-workstation-keyring/build/*.rpm
           retention-days: 5
           if-no-files-found: error

--- a/.github/workflows/lint-and-build.yml
+++ b/.github/workflows/lint-and-build.yml
@@ -1,0 +1,67 @@
+---
+name: lint-and-build
+
+on:
+  workflow_call:
+    inputs:
+      target-branch:
+        required: true
+        type: string
+        description: 'Target branch for build'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    container:
+      image: registry.fedoraproject.org/fedora:37
+    steps:
+      - run: dnf install -y git make rpmlint
+      - name: Lint target specfile
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.target-branch }}
+          persist-credentials: false
+      - run: |
+          git config --global --add safe.directory '*'
+          rpmlint rpm_spec/*.spec
+  build-rpm:
+    runs-on: ubuntu-latest
+    env:
+      CI_SKIP_PREREQS: 1
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: QubesOS/qubes-builderv2
+          path: qubes-builderv2
+      - name: Fetch latest qubes-builder tag
+        run: |
+          cd ${{ github.workspace }}/qubes-builderv2/
+          git fetch --depth=1 origin "refs/tags/*:refs/tags/*"
+      - uses: actions/checkout@v4
+        with:
+          path: securedrop-workstation-keyring
+      # See Makefile and CI_SKIP_PREREQS flag.
+      # GHA image has docker preinstalled
+      - name: Install Qubes-builderv2 dependencies
+        run: |
+          grep -v "^docker\.io$" ${{ github.workspace }}/qubes-builderv2/dependencies-debian.txt | xargs sudo apt install -y -
+      - name: Build container image
+        run: |
+          cd ${{ github.workspace }}/qubes-builderv2
+          ./tools/generate-container-image.sh docker
+      - name: Edit apparmor profile for unix-chkpwd
+        run: |
+          sudo sed -i 's/capability audit_write,$/&\n  # fix: read shadow permissions (linux-pam#686)\n  capability dac_read_search,/' /etc/apparmor.d/unix-chkpwd
+          sudo apparmor_parser -r /etc/apparmor.d/unix-chkpwd
+      - name: Build rpm
+        run: |
+          sudo apt install -y python3-pathspec
+          cd ${{ github.workspace }}/securedrop-workstation-keyring
+          make build-rpm BUILD_CONTAINER=docker BRANCH=${{ inputs.target-branch }}
+      - name: Upload RPM
+        uses: actions/upload-artifact@v4
+        id: rpm-upload-step
+        with:
+          path: ${{ github.workspace }}/securedrop-workstation-keyring/build/*.rpm
+          retention-days: 5
+          if-no-files-found: error

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -1,0 +1,58 @@
+---
+name: packages
+
+# Build test packages (dev, staging).
+# Prod packages are built outside of GHA using qubes-builderv2.
+
+jobs:
+  build-package:
+    strategy:
+      matrix:
+        target: [dev, staging]
+    # Same trust level as our repo, so we can pin to main instead of a tag/sha
+    uses: freedomofpress/securedrop-workstation-keyring/.github/workflows/lint-and-build.yml@main
+    with:
+      target-branch: ${{ matrix.target }}
+
+  commit-and-push:
+    runs-on: ubuntu-latest
+    container: debian:bookworm
+    needs:
+      - lint-and-build
+    steps:
+      - name: Install dependencies
+        run: |
+          apt-get update && apt-get install --yes git git-lfs
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: "*"
+      - uses: actions/checkout@v4
+        with:
+          repository: "freedomofpress/securedrop-yum-test"
+          path: "securedrop-yum-test"
+          lfs: true
+          # (TODO, uncomment after workflow review)
+          # token: ${{ secrets.PUSH_TOKEN }}
+          # We need to store credentials here
+          # persist-credentials: true
+      - name: Configure git user
+        run: |
+          git config --global user.email "securedrop@freedom.press"
+          git config --global user.name "sdcibot"
+          cd securedrop-yum-test
+      - if: ${{ matrix.target }} == 'dev'
+        name: Add dev keyring
+        run: |
+          mkdir -p workstation/dom0/f37-nightlies
+          cp -v ../rpm-build/*.rpm workstation/dom0/f37-nightlies/
+          git add .
+      - if: ${{ matrix.target }} == 'staging'
+        name: Add staging keyring
+        run: |
+          mkdir -p workstation/dom0/f37
+          cp -v ../rpm-build/*.rpm workstation/dom0/f37/
+          git add .
+      - name: Commit and push
+          git diff-index --quiet HEAD || git commit -m "Automated securedrop-workstation-keying ${{ matrix.target-branch }} build"
+          # (TODO, uncomment after workflow review)
+          # git push origin main

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -25,7 +25,7 @@ jobs:
           apt-get update && apt-get install --yes git git-lfs
       - uses: actions/download-artifact@v4
         with:
-          pattern: "*"
+          artifact-ids: ${{ needs.build-package.outputs.artifact-id }}
       - uses: actions/checkout@v4
         with:
           repository: "freedomofpress/securedrop-yum-test"


### PR DESCRIPTION
- Convert rpm lint + build in CI into a reusable workflow
- Create packages.yml to build  and upload dev and staging rpm and preserve artifacts
- Use workflow like https://github.com/freedomofpress/securedrop-workstation/blob/main/.github/workflows/nightlies.yml to build packages. (Note: this builds a dev package _and_ a staging package)

Comments: 
- These packages don't have to be rebuilt all the time, so there isn't a point in calling it a "nightly". 
- "dev" : think securedrop-workstation-dom0-config dev, aka "lets you install nightly builds of sdw dom0 repo"
- "staging": lets you install staging builds of sdw dom0 repo

I've left the git push and token stuff commented out for the time being to avoid any accidental pushes while under review.