### PR TITLE
Replace fedora registry with quay.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     container:
-      image: registry.fedoraproject.org/fedora:37
+      image: quay.io/fedora/fedora:37
     steps:
       - run: dnf install -y git make rpmlint
       - name: Lint specfiles


### PR DESCRIPTION
To keep in sync with workstation changes.
Refs https://github.com/freedomofpress/securedrop-workstation/pull/1387 and https://github.com/freedomofpress/securedrop-workstation/issues/1385