### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,14 @@
 
 This repository contains the material needed to bootstrap a SecureDrop
 Workstation installation - a .repo file and the SecureDrop Release Signing
-Key.
+Key (in `files`) and an rpm .spec file (in `rpm_spec`), which can be used with qubes-builderv2. A `.qubesbuilder` file is provided.
 
-The production package will be hosted in Qubes-contrib.
+This repository will be submitted for inclusion in Qubes Contrib.
 
-**At the moment this repo is experimental and should not be part of a production SDW installation.**
+## Developer setup instructions
+For developer convenience, this repository also includes make targets that bootstrap the qubes-builderv2 repo and allow developers to build and test packages signed by SecureDrop maintainers (i.e. dev and staging packages), as well as a build script.
+These files (Makefile, `sd-qubes-builder` directory) are not required for production package building via Qubes Contrib. OS-specific setup instructions are below.
 
-## Setup instructions
 ### Qubes
 On Qubes systems, clone the [qubes-builderv2](https://github.com/QubesOS/qubes-builderv2) repo in a sibling directory to this one and configure its dependencies.
 Your disposable build VM should be Fedora-based and should be called `qubes-builder-dvm`.
@@ -22,17 +23,17 @@ To set up the qubes-builderv2 repository and generate the build container, follo
 If the qubes-builderv2 repository is not already installed in a sibling directory, it will be cloned.
 OS-specific dependencies will be installed (on local machines, you'll be prompted for your passphrase) and the executor image will be generated, which takes some time.
 
-## Build instructions
+### Developer build instructions
 Run `make build-rpm`. On Qubes systems, `BUILD_OS=qubes` is required to use the Qubes Fedora executor.
 
 On succesful builds, an .rpm and .buildinfo file will be written to a `build` directory in this repository.
 
-### Build variants
+#### Build variants
 `make build-rpm`, `make build-rpm-staging`, and `make build-rpm-dev` will build respective packages using Qubes builderv2.
 
 `make build-rpm BRANCH=yourbranchname` also allows you to build from any branch.
 
-### Troubleshooting failed builds
+#### Troubleshooting failed builds
 When a build fails, you will generally see a traceback printed to the console that ends with
 
 ```
@@ -49,10 +50,10 @@ and inspect the lines before the traceback begins for more helpful debugging inf
 Traceback (most recent call last):
 [...]
 ```
-#### Dirty `artifacts` directory
+##### Dirty `artifacts` directory
 qubes-builderv2 clones a copy of the repository it's trying to build in
-`qubes-builderv2/artifacts/sources/`, and does not take kindly to force-pushes or other
-changes in git history.
+`qubes-builderv2/artifacts/sources/`, and does not take kindly to force-pushes or other changes in git history.
+The make targets in this repository force a fresh clone of the repo on each new build, but if you are building manually with your own qubes-builderv2 setup and run into build issues after force-pushing, remove `qubes-builderv2/artifacts/sources/securedrop-workstation-keyring` and `qubes-builderv2/artifacts/repository/*/securedrop-workstation-keyring` and retry.
 
 ## SecureDrop Release Signing Key
 See https://media.securedrop.org/media/documents/securedrop-release-key-2021-2.asc for verification.


### PR DESCRIPTION
Update readme to clarify production vs developer-facing components, and clarify that Makefile build instructions are for developer-only workflows and not qubes contrib.