### PR TITLE
Support Qubes 4.3 as Target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
           git config --global --add safe.directory '*'
           rpmlint rpm_spec/*.spec
   build-rpm:
+    strategy:
+      matrix:
+        qubes_release: ["4.2", "4.3"]
     runs-on: ubuntu-latest
     needs: [ "lint" ]
     # merge queue branch name confuses the builder
@@ -51,16 +54,22 @@ jobs:
         run: |
           sudo sed -i 's/capability audit_write,$/&\n  # fix: read shadow permissions (linux-pam#686)\n  capability dac_read_search,/' /etc/apparmor.d/unix-chkpwd
           sudo apparmor_parser -r /etc/apparmor.d/unix-chkpwd
-      - name: Build rpm
+      - name: Build rpm (Qubes ${{ matrix.qubes_release }})
         run: |
           sudo apt install -y python3-pathspec
           cd ${{ github.workspace }}/securedrop-workstation-keyring
-          make build-rpm BUILD_CONTAINER=docker BRANCH=${{ env.BRANCH_NAME }}
+          make build-rpm BUILD_CONTAINER=docker BRANCH=${{ env.BRANCH_NAME }} QUBES_RELEASE=${{ matrix.qubes_release }}
+      - name: Test Correct repo version
+        run: |
+          sudo apt install -y rpm2cpio
+          cd ${{ github.workspace }}/securedrop-workstation-keyring/build/
+          expected_dom0_fedora=${{ fromJson('{"4.2": "fc37", "4.3": "fc41"}')[matrix.qubes_version] }}
+          rpm2cpio *.rpm | grep --text "baseurl=.*$expected_dom0_fedora"
       - name: Upload RPM
         uses: actions/upload-artifact@v4
         id: rpm-upload-step
         with:
-          name: rpm-${{ env.BRANCH_NAME }}
+          name: rpm-${{ env.BRANCH_NAME }}-${{ matrix.qubes_release }}
           path: ${{ github.workspace }}/securedrop-workstation-keyring/build/*.rpm
           retention-days: 5
           if-no-files-found: error

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,14 @@ BRANCH ?= "main"
 # On CI, manually install OS dependencies
 CI_SKIP_PREREQS ?= 0
 
+# Which Qubes version to target.
+# FEDORA_DIST is as specified in `distributions` section of builderv2 .yml
+QUBES_RELEASE ?= "4.2"
+FEDORA_DIST = "host-fc37"
+ifeq ($(QUBES_RELEASE),4.3)
+	FEDORA_DIST = "host-fc41"
+endif
+
 # The executor can be docker or podman, or the Qubes Fedora dispvm executor.
 BUILD_CONTAINER ?= $(notdir $(shell command -v docker 2>/dev/null || command -v podman 2>/dev/null))
 EXECUTOR ?= "docker"
@@ -73,7 +81,9 @@ prepare: ## Configure plugins, verify tag
 # Reprotest requires the qubes-builder clone step to be included
 .PHONY: build-rpm
 build-rpm: $(if $(REPROTEST),qubes-builder) prepare ## Build rpm (default: prod)
-	@BRANCH=$(BRANCH) EXECUTOR=$(EXECUTOR) EXECUTOROPTS=$(EXECUTOROPTS) sd-qubes-builder/build-rpm.sh
+	@BRANCH=$(BRANCH) EXECUTOR=$(EXECUTOR) EXECUTOROPTS=$(EXECUTOROPTS) \
+	QUBES_RELEASE=$(QUBES_RELEASE) FEDORA_DIST=$(FEDORA_DIST) \
+	sd-qubes-builder/build-rpm.sh
 
 .PHONY: build-rpm-dev
 build-rpm-dev: ## Build dev rpm (test key, yum-test f37-nightly repo)
@@ -87,7 +97,11 @@ build-rpm-staging: ## Build staging rpm (test key, yum-test f37 repo)
 reprotest: ## Test reproducibility
 	@which reprotest > /dev/null || (echo "Install reprotest" && exit 1)
 	@test -e build/*.rpm || (echo "Run \`make build-rpm\` first" && exit 1)
-	@sudo reprotest 'REPROTEST=1 make build-rpm BRANCH="${BRANCH}" EXECUTOR="${EXECUTOR}" EXECUTOROPTS="${EXECUTOROPTS}"' 'build/*.rpm' --variations '+all,+kernel,-time,-fileordering,-domain_host'
+	@sudo reprotest 'REPROTEST=1 make build-rpm BRANCH="${BRANCH}" \
+		EXECUTOR="${EXECUTOR}" EXECUTOROPTS="${EXECUTOROPTS}" \
+		QUBES_RELEASE="${QUBES_RELEASE}" QUBES_BRANCH="${QUBES_BRANCH}" \
+		FEDORA_DIST="${FEDORA_DIST}"' \
+		'build/*.rpm' --variations '+all,+kernel,-time,-fileordering,-domain_host'
 
 ## The below commands should run in CI or a Fedora environment
 # FIXME: the time variations have been temporarily removed from reprotest

--- a/Makefile
+++ b/Makefile
@@ -99,8 +99,7 @@ reprotest: ## Test reproducibility
 	@test -e build/*.rpm || (echo "Run \`make build-rpm\` first" && exit 1)
 	@sudo reprotest 'REPROTEST=1 make build-rpm BRANCH="${BRANCH}" \
 		EXECUTOR="${EXECUTOR}" EXECUTOROPTS="${EXECUTOROPTS}" \
-		QUBES_RELEASE="${QUBES_RELEASE}" QUBES_BRANCH="${QUBES_BRANCH}" \
-		FEDORA_DIST="${FEDORA_DIST}"' \
+		QUBES_RELEASE="${QUBES_RELEASE}" FEDORA_DIST="${FEDORA_DIST}"' \
 		'build/*.rpm' --variations '+all,+kernel,-time,-fileordering,-domain_host'
 
 ## The below commands should run in CI or a Fedora environment

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ On succesful builds, an .rpm and .buildinfo file will be written to a `build` di
 
 `make build-rpm BRANCH=yourbranchname` also allows you to build from any branch.
 
+`make build-rpm QUBES_RELEASE=4.3` allows you to build to target another Qubes version
+
 #### Troubleshooting failed builds
 When a build fails, you will generally see a traceback printed to the console that ends with
 

--- a/files/securedrop-workstation-dom0.repo.in
+++ b/files/securedrop-workstation-dom0.repo.in
@@ -3,5 +3,5 @@ gpgcheck=1
 skip_if_unavailable=False
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-securedrop-workstation
 enabled=1
-baseurl=https://yum.securedrop.org/workstation/dom0/f37
+baseurl=https://yum.securedrop.org/workstation/dom0/@DIST@
 name=SecureDrop Workstation Qubes dom0 repo

--- a/rpm_spec/securedrop-workstation-keyring.spec
+++ b/rpm_spec/securedrop-workstation-keyring.spec
@@ -46,7 +46,8 @@ This package contains the SecureDrop Release Signing Key and .repo file used to 
 %install
 install -m 755 -d %{buildroot}/etc/yum.repos.d
 install -m 755 -d %{buildroot}/etc/pki/rpm-gpg
-install -m 644 files/securedrop-workstation-dom0.repo %{buildroot}/etc/yum.repos.d/
+install -m 644 files/securedrop-workstation-dom0.repo.in %{buildroot}/etc/yum.repos.d/securedrop-workstation-dom0.repo
+sed -i "s/@DIST@/fc%{fedora}/g" %{buildroot}/etc/yum.repos.d/securedrop-workstation-dom0.repo
 install -m 644 files/securedrop-release-signing-pubkey-2021.asc %{buildroot}/etc/pki/rpm-gpg/RPM-GPG-KEY-securedrop-workstation
 
 %files

--- a/sd-qubes-builder/build-rpm.sh
+++ b/sd-qubes-builder/build-rpm.sh
@@ -10,6 +10,8 @@ set -o pipefail
 : "${BRANCH:?BRANCH missing; use make build-rpm}"
 : "${EXECUTOR:?EXECUTOR missing; use make build-rpm}"
 : "${EXECUTOROPTS:?EXECUTOROPTS missing; use make build-rpm}"
+: "${QUBES_RELEASE:?QUBES_RELEASE missing; use make build-rpm}"
+: "${FEDORA_DIST:?FEDORA_DIST missing; use make build-rpm}"
 
 echo "Copy sd-builder.yml into qubes-builderv2 repo"
 cp sd-qubes-builder/sd-builder.yml.conf ../qubes-builderv2/sd-builder.yml
@@ -29,12 +31,16 @@ echo "Remove SDW-keyring sources from qubes-builder"
 rm -rf ../qubes-builderv2/artifacts/sources/securedrop-workstation-keyring || true
 rm -rf ../qubes-builderv2/artifacts/repository/*/securedrop-workstation-keyring* || true
 
-echo "Begin build..."
+echo "Begin build for Qubes Version ${QUBES_RELEASE} (${FEDORA_DIST})"
 (
   cd ../qubes-builderv2
   ./qb --builder-conf sd-builder.yml \
+      --option use-qubes-repo:version=${QUBES_RELEASE} \
+      --option qubes-release=r${QUBES_RELEASE} \
       --option executor:type="${EXECUTOR}" \
       --option executor:options:"${EXECUTOROPTS}" \
+      --option +distributions+"${FEDORA_DIST}" \
+      -d "${FEDORA_DIST}" \
       -c securedrop-workstation-keyring package fetch prep build
 )
 

--- a/sd-qubes-builder/sd-builder.yml.conf
+++ b/sd-qubes-builder/sd-builder.yml.conf
@@ -12,16 +12,20 @@ git:
 backend-vmm: xen
 debug: true
 verbose: true
-qubes-release: r4.2
-use-qubes-repo:
-  version: 4.2
-  testing: false
+
+# Specified dynamically in build-rpm.sh
+# qubes-release: r4.2
+# use-qubes-repo:
+#  version: 4.2
+#  testing: false
+
+# Specified dynamically
+# distributions:
+#  - host-fc37
+#  - host-fc41
 
 #### Enable this to develop directly in artifacts/sources/securedrop-workstation-keyring
 # skip-git-fetch: true
-
-distributions:
-  - host-fc37
 
 components:
   - builder-rpm:

--- a/sd-qubes-builder/sd-builder.yml.conf
+++ b/sd-qubes-builder/sd-builder.yml.conf
@@ -1,7 +1,8 @@
 git:
   baseurl: https://github.com
   prefix: QubesOS/qubes-
-  branch: release4.2
+  # Default branch bellow is not really relevant (no qubes components being built)
+  branch: main
   maintainers:
     # marmarek
     - '0064428F455451B3EBE78A7F063938BA42CFA724'
@@ -25,10 +26,8 @@ distributions:
 components:
   - builder-rpm:
       packages: False
-      branch: main
   - builder-debian:
       packages: False
-      branch: main
   - securedrop-workstation-keyring:
       branch: {{branch}} # <--- See Makefile. Defaults to `main`
       url: https://github.com/freedomofpress/securedrop-workstation-keyring

--- a/sd-qubes-builder/sd-builder.yml.conf
+++ b/sd-qubes-builder/sd-builder.yml.conf
@@ -1,7 +1,7 @@
 git:
   baseurl: https://github.com
   prefix: QubesOS/qubes-
-  # Default branch bellow is not really relevant (no qubes components being built)
+  # Default branch below is not really relevant (no qubes components being built)
   branch: main
   maintainers:
     # marmarek


### PR DESCRIPTION
Makes repo dom0-version-agnostic. Fixes #23 by replicating approach taken in [Qubes' meta-packages repo](https://github.com/QubesOS/qubes-meta-packages/blob/12f02e8ba9d5d04ddb71f7557992a6d56057c3d7/repos/Makefile#L30) of using `@DIST@` in .spec, and then replace it with sed.


Open unknowns (unanswered by PR alone)
- [ ] what happens with actually hosted repos?

## Build and Test Plan
- [x] CI passes (should cover the test cases bellow as well)

Qubes 4.2:
- [x] `make build-rpm BRANCH=23-dom0-dist-agnostic QUBES_RELEASE=4.2`
- [x] Ensure `baseurl` ends in `fc37`:
   ```
   rpm2cpio build/*.rpm | grep --text "baseurl"
   ```

Qubes 4.3:
- [x] `make build-rpm BRANCH=23-dom0-dist-agnostic QUBES_RELEASE=4.3`
- [x] Ensure `baseurl` ends in `fc41`:
   ```
   rpm2cpio build/*.rpm | grep --text "baseurl"
   ```


<strike>Qubes 4.2 -> Qubes 4.3 upgrade (from locally-installed package):</strike>
 (**Note** not yet doable due to missing repos. Do we want to set these up to simulate more closely?)
- [ ] (on a non-critical machine) install keyring RPM in Qubes 4.2 (without SDW installed)
- [ ] enable testing repositories and apply dom0 updates
- [ ] follow inplace upgrade with [the necessary options](https://www.qubes-os.org/news/2025/08/10/qubes-os-4-3-0-rc1-available-for-testing/#how-to-test-qubes-430-rc1) (`sudo qubes-dist-upgrade --releasever=4.3 --enable-current-testing --all-pre-reboot`, then reboot + same cmd with `--all-post-reboot`)
- [ ] after upgrade, confirm keyring package is present (in its 4.3 version) and that the keyring file it installed has the appropriate repo file (baseurl with `fc41`).


## Post-merge tasks
- [ ] backport to `dev` and `staging` branches