### PR TITLE
Auto-update dev and staging branches via GHA

### DIFF
--- a/.github/workflows/update_branch.yml
+++ b/.github/workflows/update_branch.yml
@@ -1,0 +1,62 @@
+name: Rebase long-running dev and staging branches on main
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  rebase-and-pr:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+      - run: git fetch --all
+      - name: Rebase branches and create PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          for ENV in dev staging; do
+
+            # Rebase last commit on main
+            git checkout origin/$ENV -b rebase-$ENV
+            git reset --soft HEAD~1
+            git stash
+
+            git rebase origin/main
+            git stash apply || true
+            git add -A
+
+            # Timestamped commit message
+            TIMESTAMP=$(date -u +"%Y%m%d%H%M%S")
+            COMMIT_MSG="$ENV sdw-keyring package configuration auto-update ($TIMESTAMP). To build a securedrop-workstation-keyring-$ENV package, target this branch in your qubes builderv2 builder.yml file. This is a long-running $ENV branch not intended for merge."
+
+            git commit -m "$COMMIT_MSG"
+
+            # Push to temporary branch
+            git push -u origin rebase-$ENV --force
+
+            PR_BODY=$(cat <<EOF
+I am a bot; this PR was opened automatically.
+
+$COMMIT_MSG
+
+### Test plan:
+- [ ] Visual review
+- [ ] Base branch is $ENV
+EOF
+)
+
+            # Create pull request
+            gh pr create \
+              --title "$ENV keyring auto-update ($TIMESTAMP)" \
+              --body "$PR_BODY" \
+              --base $ENV \
+              --head rebase-$ENV
+
+          done


### PR DESCRIPTION
To avoid `dev` and `staging` being out of date, create a github action that triggered on pushes to main that opens PRs rebasing the `dev` and `staging` branches on top of main. If we're comfortable trusting Github, we could equally have Github push directly to those branches, too; the builds won't succeed without a tag from a maintainer.

Note: this Github actions workflow was mostly AI-generated. If we like the idea of it, we can improve/adjust.