### PR TITLE
Correct DIST substitution in dom0 config spec

### DIFF
--- a/rpm_spec/securedrop-workstation-keyring.spec
+++ b/rpm_spec/securedrop-workstation-keyring.spec
@@ -47,7 +47,7 @@ This package contains the SecureDrop Release Signing Key and .repo file used to 
 install -m 755 -d %{buildroot}/etc/yum.repos.d
 install -m 755 -d %{buildroot}/etc/pki/rpm-gpg
 install -m 644 files/securedrop-workstation-dom0.repo.in %{buildroot}/etc/yum.repos.d/securedrop-workstation-dom0.repo
-sed -i "s/@DIST@/fc%{fedora}/g" %{buildroot}/etc/yum.repos.d/securedrop-workstation-dom0.repo
+sed -i "s/@DIST@/f%{fedora}/g" %{buildroot}/etc/yum.repos.d/securedrop-workstation-dom0.repo
 install -m 644 files/securedrop-release-signing-pubkey-2021.asc %{buildroot}/etc/pki/rpm-gpg/RPM-GPG-KEY-securedrop-workstation
 
 %files


### PR DESCRIPTION
When we introduced the DIST substitution, we incorrectly specified the dom0 config rpm URL; the path should be https://yum.securedrop.org/workstation/dom0/f$FEDORA_VERSION, not /fc$FEDORA_VERSION. 


## Test plan
- [x] CI
- [x] Check path of a prod dom0 config rpm at https://yum.securedrop.org/index.html 
 