### PR TITLE
Replace baseurl: use Qubes release instead of fedora

### DIFF
--- a/files/securedrop-workstation-dom0.repo.in
+++ b/files/securedrop-workstation-dom0.repo.in
@@ -3,5 +3,5 @@ gpgcheck=1
 skip_if_unavailable=False
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-securedrop-workstation
 enabled=1
-baseurl=https://yum.securedrop.org/workstation/dom0/@DIST@
+baseurl=https://yum.securedrop.org/workstation/dom0/r$releasever
 name=SecureDrop Workstation Qubes dom0 repo

--- a/rpm_spec/securedrop-workstation-keyring.spec.in
+++ b/rpm_spec/securedrop-workstation-keyring.spec.in
@@ -47,7 +47,6 @@ This package contains the SecureDrop Release Signing Key and .repo file used to 
 install -m 755 -d %{buildroot}/etc/yum.repos.d
 install -m 755 -d %{buildroot}/etc/pki/rpm-gpg
 install -m 644 files/securedrop-workstation-dom0.repo.in %{buildroot}/etc/yum.repos.d/securedrop-workstation-dom0.repo
-sed -i "s/@DIST@/f%{fedora}/g" %{buildroot}/etc/yum.repos.d/securedrop-workstation-dom0.repo
 install -m 644 files/securedrop-release-signing-pubkey-2021.asc %{buildroot}/etc/pki/rpm-gpg/RPM-GPG-KEY-securedrop-workstation
 
 %files


### PR DESCRIPTION
Fixes #23

**NOTE:** Adding both `r$releasever` (Qubes release) and `fcXX` (dom0 fedora version) would complicate things. I share some notes in another ticket:
  
   > <details><summary>Under the hood stages of qubes-repo-contrib during a qubes-dist-upgrade</summary>
   > 
   > ```
   > # Start in Qubes 4.2 and install qubes-repo-contrib
   > sudo qubes-dom0-update -y qubes-repo-contrib # Installs qubes-repo-contrib 4.2.15-1.fc37
   > 
   > # Then upgrade qubes-repo-contrib to its 4.3 version, while still on fedora-37
   > sudo qubes-dom0-update --action=update --releasever=4.3 --enablerepo=qubes-dom0-current-testing qubes-repo-contrib  # Installs qubes-repo-contrib 4.3.0-1.fc37
   > 
   > # Following qubes-dist-upgrade (stage 2) - https://github.com/QubesOS/qubes-dist-upgrade/blob/main/scripts/qubes-dist-upgrade-r4.3.sh#L320 
   > # Updates qubes repos so it is effectively treated as having a qubes 4.3 releasever -> this means that it'll now fetch fedora-41 repos
   > sudo qubes-dom0-update --action=update --releasever=4.3 --enablerepo=qubes-release
   > 
   > sudo qubes-dom0-update --action=update --releasever=4.3 --enablerepo=qubes-dom0-current-testing qubes-repo-contrib  # Installs qubes-repo-contrib 4.3.4-1.fc41
   > 
   > grep "baseurl=" /etc/yum.repos.d/qubes-contrib-dom0-r4.2.repo
   > # Will print [...]/yum/r4.2/current-testing/host/fc41  <- this is because it has r4.2 harcoded instead of $releasever
   > ```
   > 
   > The following is a breakdown of the various versions we just cycled through:
   > 
   > | Version | Obtained in yum.qubes-os.org/… | baseurl in RPM (trimmed) | `$releasever` | `@DIST@`
   > |-- | -- | -- | -- | -- |
   > | `4.2.15-1` | `r4.2/current/host/fc37/rpm/` | `/yum/r4.2/current/host/fc37` | `4.2` | `fc37`
   > | `4.3.0-1` | `r4.3/current/host/fc37/rpm/` | `/yum/r4.2/current-testing/host/fc37` | `4.2` (bug?) | `fc37`
   > | `4.3.4-1` | `r4.3/current/host/fc41/rpm/` | `/yum/r4.2/current-testing/host/fc41` | `4.2` (bug?) | `fc41`
   > 
   > In practice, when using `qubes-dist-upgrade`, this goes from version `4.2.15` to `4.3.4`  directly. But the result is the same
   > 
   > </details>
   > 
   > — _Originally posted by @deeplow in [#1508](https://github.com/freedomofpress/securedrop-workstation/issues/1508#issuecomment-3602366759)_

<strike>**Blocking this**: on upstream feedback whether or not it is safe to assume that outside of Qubes testing, there is a 1:1 mapping between a Fedora dom0 version and a Qubes release.</strike>
*(**Update** per team discussion we'll just move forward with this to unblock testing, worst-case we revert course — CC @legoktm)*


To be merged after:
- <strike>https://github.com/freedomofpress/securedrop-workstation/pull/1511</strike> (**update**: no longer needed)
- https://github.com/freedomofpress/securedrop-yum-test/pull/83