### PR TITLE
Improve RPM key management accuracy

### DIFF
--- a/rpm_spec/securedrop-workstation-keyring.spec.in
+++ b/rpm_spec/securedrop-workstation-keyring.spec.in
@@ -13,10 +13,14 @@ Summary:    SecureDrop Workstation Keyring
 %define previous_gpg_key gpg-pubkey-00000000-00000000
 %define current_gpg_key gpg-pubkey-7b22e6a3-609966ad
 #
-#   * The following macro is needed because RPM key database operations cannot
+#   * The following macros are needed because RPM key database operations cannot
 #     happen in dnf<5 during an RPM package installation / uninstallation, etc.
 #     The trick is to schedule them to happen after RPM finishes.
 %define systemd_timer systemd-run --timer-property=AccuracySec=1s --on-active=2s timeout 15m
+#
+#     Import current key (NOTE: key expiry bumps may keep the same 'key name')
+%define import_current_key %{systemd_timer} sh -c 'while ! rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-securedrop-workstation; do sleep 2; done'
+%define purge_key() %{systemd_timer} sh -c 'while rpm -q %{1} && ! rpm -e %{1}; do sleep 2; done'
 
 # For reproducible builds:
 #
@@ -71,7 +75,7 @@ install -m 644 files/securedrop-release-signing-pubkey-2021.asc %{buildroot}/etc
 %postun
 # Uninstall
 if [ $1 -eq 0 ] ; then
-    %{systemd_timer} sh -c 'while rpm -q %{current_gpg_key} && ! rpm -e %{current_gpg_key}; do sleep 2; done'
+    %{purge_key %{current_gpg_key}}
 fi
 
 %posttrans
@@ -83,15 +87,12 @@ fi
 #
 # New install
 if [ $1 -eq 1 ] ; then
-    %{systemd_timer} sh -c 'while ! rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-securedrop-workstation; do sleep 2; done'
+    %{import_current_key}
 fi
 # Upgrade. Uninstall old key then install new key.
 if [ $1 -gt 1 ] ; then
-    # Purge previous keys
-    %{systemd_timer} sh -c 'while rpm -q %{previous_gpg_key} && ! rpm -e %{previous_gpg_key}; do sleep 2; done'
-
-    # Import the new key (NOTE: key expiry bumps may keep the same 'key name')
-    %{systemd_timer} sh -c 'while ! rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-securedrop-workstation; do sleep 2; done'
+    %{purge_key %{previous_gpg_key}}
+    %{import_current_key}
 fi
 
 %changelog


### PR DESCRIPTION
Fixes #36 by installing the keyring faster than 15 seconds.

## Test plan
In `sd-dev`:
  - [ ] clone this repo (no need to change into this specific branch)
  - [ ] `make qubes-builder` (if you haven't already)
  - [ ] `make build-rpm QUBES_RELEASE=4.2 BRANCH=36-improve-import-accuracy`

In `dom0`:
  - [ ] open terminal
  - [ ] copy to RPM dom0 (`qvm-run run -p sd-dev "cat securedrop-workstation-keyring/build/securedrop-workstation-keyring-0.2.0-1.fc37.noarch.rpm" |tee securedrop-workstation-keyring-0.2.0-1.fc37.noarch.rpm`)
  - [ ] ensure `sudo dnf remove -y securedrop-workstation-keyring` (if not already)
  - [ ] *Key monitoring terminal —*(this will be refered through testing
    Open a new terminal window to monitor for new keys (for example, I use `watch -n 0.1 "rpm -qi gpg-pubkey-*  | grep -i securedrop"`)

### Regular keyring installation

In `dom0`:
- [x] Ensure no key is listed (in key monitoring terminal)
- [x] `sudo dnf install build/securedrop-workstation-keyring-0.2.0-1.fc37.noarch.rpm`
- [ ] Confirm key was installed within a few seconds (less than 15s is the goal)

### Delayed RPM installation simulation
_This tests a scenario where `rpm --import` fails the first time it tries._

In `dom0`:
- [ ] Ensure no key is listed (in key monitoring terminal)
- [ ] (In a **third terminal**) attempt to constantly remove the key:
    `watch -n 0.1 "sudo mv /etc/pki/rpm-gpg/RPM-GPG-KEY-securedrop-workstation sdw-gpg-key`
- [ ] Install keyring (copy the timer it started — e.g.: `run-r4746fa479eb7433e9a62ede5fbbdab8d.timer`)
- [ ] (wait 10 seconds) run `sudo systemctl status <insert_timer>.timer` — it should **still** be listed as "active"
- [ ] (in the **third terminal**) cancel the `watch` command and run the command that follows. After that, the key should appear within seconds in the *key monitoring terminal*:
   `sudo mv sdw-gpg-key /etc/pki/rpm-gpg/RPM-GPG-KEY-securedrop-workstation`
- [ ] run `sudo systemctl status <insert_timer>.timer` — it should **no longer** be listed as "active"

### Upgrade scenario
- [ ] change `version` file to `0.3.0`, rebuild package and copy to dom0
- [ ] start monitoring for the available keys
- [ ] install 0.2.0 keyring (before this PR — ­can be from qubes-contrib)
- [ ] install newly built "0.3.0" RPM and `watch -n 0.1` the installed keys:
   - [ ] keys _(may)_ disappear for a split-second and re-apper
   - [ ] there are two listed systemd timers (one for old key removal and one for adding the current key)

### Uninstall Scenario
- [ ] Install keyring  (`sudo dnf install path/to/keyring.rpm`)
- [ ] Uninstall keyring (`sudo dnf remove securedrop-workstation-keyring`)
  - [ ] keyring disappears after a few seconds

### Other scenarios not covered

- Upgrade scenario with different GPG key (*locally tested during development*)

   1. Change the following
   ```diff
    diff --git a/rpm_spec/securedrop-workstation-keyring.spec.in b/rpm_spec/securedrop-workstation-keyring.spec.in
    index 8aa237b..3a44558 100644
    --- a/rpm_spec/securedrop-workstation-keyring.spec.in
    +++ b/rpm_spec/securedrop-workstation-keyring.spec.in
    @@ -10,8 +10,8 @@ Summary:    SecureDrop Workstation Keyring
     #     last 8 characters of the GPG key's fingerprint, and $CREATIONDATE is the
     #     key creation date, expressed as:
     #       `date -d "1970-1-1 + $((0x$CREATION_UNIX_EPOCH)) sec`
    -%define previous_gpg_key gpg-pubkey-00000000-00000000
    -%define current_gpg_key gpg-pubkey-7b22e6a3-609966ad
    +%define previous_gpg_key gpg-pubkey-7b22e6a3-609966ad
    +%define current_gpg_key gpg-pubkey-3fab65ab-660f2beb
     #
     #   * The following macros are needed because RPM key database operations cannot
     #     happen in dnf<5 during an RPM package installation / uninstallation, etc.
    ```

   2. Replace the GPG key in `files/securedrop-release-signing-key-2021.asc` with [this one](https://github.com/freedomofpress/securedrop-workstation/blob/main/securedrop_salt/apt-test-pubkey.asc).

- Upgrade scenario with same GPG but with its expiration key bumped (it should keep the same RPM 'gpg ID') --- making sure the key was imported and is no longer expired in the RPM database.
