### PR TITLE
Add support for local development (`BRANCH=local`)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,10 @@ build-rpm: $(if $(REPROTEST),qubes-builder) prepare ## Build rpm (default: prod)
 	scripts/build-rpm.sh
 
 .PHONY: build-rpm-dev
+build-rpm-local: ## Build rpm from locally checked out code (for development)
+	$(MAKE) build-rpm BRANCH=local
+
+.PHONY: build-rpm-dev
 build-rpm-dev: ## Build dev rpm (test key, yum-test f37-nightly repo)
 	$(MAKE) build-rpm BRANCH=dev
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ On succesful builds, an .rpm and .buildinfo file will be written to a `build` di
 #### Build variants
 `make build-rpm`, `make build-rpm-staging`, and `make build-rpm-dev` will build respective packages using Qubes builderv2.
 
+`make build-rpm-local` build from the local repo.
+
 `make build-rpm BRANCH=yourbranchname` also allows you to build from any branch.
 
 `make build-rpm QUBES_RELEASE=4.3` allows you to build to target another Qubes version

--- a/scripts/build-rpm.sh
+++ b/scripts/build-rpm.sh
@@ -15,21 +15,36 @@ set -o pipefail
 
 echo "Copy sd-builder.yml into qubes-builderv2 repo"
 cp sd-qubes-builder/sd-builder.yml.conf ../qubes-builderv2/sd-builder.yml
-
-echo "Build from ${BRANCH}"
 sed -i "s/{{branch}}/${BRANCH}/g" "../qubes-builderv2/sd-builder.yml"
 
 echo "Remove old build artifacts if present"
 rm -rf build || true
 
 # qubes-builderv2 repo clones and caches a copy of the target
-# git repository. If building from branches that have had
-# force-pushes, or if switching branches, stale git artifacts
-# or a requirement for a rebase can break the qubes-builder
-# automation. 
 echo "Remove SDW-keyring sources from qubes-builder"
 rm -rf ../qubes-builderv2/artifacts/sources/securedrop-workstation-keyring || true
 rm -rf ../qubes-builderv2/artifacts/repository/*/securedrop-workstation-keyring* || true
+
+if [ "${BRANCH}" == "local" ]; then
+    # OPTION 1: BUILDING FROM LOCAL DIRECTORY
+    # Replace Qubes Builder's fetch with a symlink to this repo's directory
+    REPO_ROOT=$(dirname $(dirname $(realpath $0)))
+    if [ ! -d "$REPO_ROOT/.git" ]; then  # Check in case script changes location
+        echo "ERROR: $REPO_ROOT not project root" >&2 && exit 1
+    fi
+
+    # Create sources directory (needed in first run)
+    mkdir -p ../qubes-builderv2/artifacts/sources/
+
+    ln -s $REPO_ROOT ../qubes-builderv2/artifacts/sources/securedrop-workstation-keyring
+    SKIP_GIT_FETCH="true"
+else
+    # OPTION 2: BUILDING FROM BRANCH
+    # If building from branches that have had force-pushes, or if
+    # switching branches, stale git artifacts or a requirement for a rebase can
+    # break the qubes-builder automation. Therefore, these sources are re-fetched.
+    echo "Build from ${BRANCH}"
+fi
 
 echo "Begin build for Qubes Version ${QUBES_RELEASE} (${FEDORA_DIST})"
 (
@@ -39,6 +54,7 @@ echo "Begin build for Qubes Version ${QUBES_RELEASE} (${FEDORA_DIST})"
       --option qubes-release=r${QUBES_RELEASE} \
       --option executor:type="${EXECUTOR}" \
       --option executor:options:"${EXECUTOROPTS}" \
+      --option skip-git-fetch=${SKIP_GIT_FETCH:-'false'} \
       --option +distributions+"${FEDORA_DIST}" \
       -d "${FEDORA_DIST}" \
       -c securedrop-workstation-keyring package fetch prep build


### PR DESCRIPTION
Supports building from local branch by skipping the fetch stage in the Qubes Builder. This improves the local development process. Fixes #18 